### PR TITLE
重构 CertService，添加 Provider

### DIFF
--- a/AliCdnSSLWorker/CertProvider/ICertProvider.cs
+++ b/AliCdnSSLWorker/CertProvider/ICertProvider.cs
@@ -1,0 +1,21 @@
+﻿using AliCdnSSLWorker.Models;
+
+namespace AliCdnSSLWorker.CertProvider;
+
+public interface ICertProvider
+{
+    public Task<CertInfo?> GetMatchedCertByDomain(DomainInfo domain)
+        => GetMatchedCertByDomain(domain, CancellationToken.None);
+
+    public Task<CertInfo?> GetMatchedCertByDomain(DomainInfo domain, CancellationToken token);
+
+    public Task<CertInfo?> GetMatchedCertByDomain(string identify)
+        => GetMatchedCertByDomain(identify, CancellationToken.None);
+
+    public Task<CertInfo?> GetMatchedCertByDomain(string identify, CancellationToken token);
+
+    public Task<IList<CertInfo>> GetAllCerts()
+        => GetAllCerts(CancellationToken.None);
+
+    public Task<IList<CertInfo>> GetAllCerts(CancellationToken token);
+}

--- a/AliCdnSSLWorker/CertProvider/LocalCertProvider.cs
+++ b/AliCdnSSLWorker/CertProvider/LocalCertProvider.cs
@@ -31,7 +31,7 @@ public class LocalCertProvider(
     {
         try
         {
-            var cert = X509Certificate2.CreateFromPemFile(Path.Combine(path, options.Value.CertFileName), Path.Combine(identify, options.Value.PrivateKeyFileName));
+            var cert = X509Certificate2.CreateFromPemFile(Path.Combine(path, options.Value.CertFileName), Path.Combine(path, options.Value.PrivateKeyFileName));
             var certName = cert.GetNameInfo(X509NameType.SimpleName, false);
             var certContent = cert.ExportCertificatePem();
 
@@ -43,7 +43,7 @@ public class LocalCertProvider(
                     CertExpireDate = cert.NotAfter,
                     FullChain = certContent,
                     PrivateKey = keyContent!,
-                    Path = path
+                    IdentityName = path
                 });
 
             // export failed

--- a/AliCdnSSLWorker/CertProvider/LocalCertProvider.cs
+++ b/AliCdnSSLWorker/CertProvider/LocalCertProvider.cs
@@ -1,0 +1,107 @@
+﻿using System.Security.Cryptography.X509Certificates;
+using AliCdnSSLWorker.Configs;
+using AliCdnSSLWorker.Extensions;
+using AliCdnSSLWorker.Models;
+using Microsoft.Extensions.Options;
+
+namespace AliCdnSSLWorker.CertProvider;
+
+public class LocalCertProvider(
+    ILogger<LocalCertProvider> logger,
+    IOptions<LocalCertProviderConfig> options)
+        : ICertProvider
+{
+    /// <summary>
+    /// Get matched cert by domain
+    /// </summary>
+    /// <param name="domain">domain info</param>
+    /// <param name="token"></param>
+    /// <returns>domain info or null</returns>
+    public async Task<CertInfo?> GetMatchedCertByDomain(DomainInfo domain, CancellationToken token)
+        => (await GetAllCerts(token)).OrderBy(c => c.CertCommonName.MatchedCount(domain))
+             .FirstOrDefault();
+
+    /// <summary>
+    /// Get matched cert by file identify
+    /// </summary>
+    /// <param name="path">file full name</param>
+    /// <param name="token"></param>
+    /// <returns>Found <see cref="DomainInfo"/> or <see langword="null"/></returns>
+    public Task<CertInfo?> GetMatchedCertByDomain(string path, CancellationToken token)
+    {
+        try
+        {
+            var cert = X509Certificate2.CreateFromPemFile(Path.Combine(path, options.Value.CertFileName), Path.Combine(identify, options.Value.PrivateKeyFileName));
+            var certName = cert.GetNameInfo(X509NameType.SimpleName, false);
+            var certContent = cert.ExportCertificatePem();
+
+            // export success
+            if (cert.TryExportPrivateKeyPem(out var keyContent))
+                return Task.FromResult<CertInfo?>(new()
+                {
+                    CertCommonName = DomainInfo.Parse(certName),
+                    CertExpireDate = cert.NotAfter,
+                    FullChain = certContent,
+                    PrivateKey = keyContent!,
+                    Path = path
+                });
+
+            // export failed
+            logger.LogWarning("UnSupport signature algorithm `{oid}`", cert.SignatureAlgorithm);
+            return Task.FromResult<CertInfo?>(null);
+        }
+        catch (Exception e)
+        {
+            logger.LogError(e, "Load cert error.");
+        }
+
+        return Task.FromResult<CertInfo?>(null);
+    }
+
+    public async Task<IList<CertInfo>> GetAllCerts(CancellationToken token)
+    {
+        var list = new List<CertInfo>();
+
+        var dir = new DirectoryInfo(options.Value.SearchPath);
+        if (!dir.Exists)
+        {
+            logger.LogError("Dir {d} isn't exists!", dir.FullName);
+            return list;
+        }
+
+        if (options.Value.RecursionSearch)
+        {
+            var dirList = dir.GetDirectories();
+            await Parallel.ForEachAsync(dirList, token, async (subDir, innerToken) =>
+                await GetAllCertsCore(subDir, list.Add, innerToken));
+        }
+        else
+        {
+            await GetAllCertsCore(dir, list.Add, token);
+        }
+
+        return list;
+    }
+
+    private async ValueTask GetAllCertsCore(DirectoryInfo dir, Action<CertInfo> invoked, CancellationToken token)
+    {
+        var certFile = dir.GetFiles(options.Value.CertFileName);
+        var privateFile = dir.GetFiles(options.Value.PrivateKeyFileName);
+
+        if (certFile.Length != 1 || privateFile.Length != 1)
+        {
+            logger.LogWarning("Can not found cert or private key file, skip {d}", dir.Name);
+            return;
+        }
+
+        var cert = await GetMatchedCertByDomain(dir.FullName, token);
+
+        if (cert is null)
+        {
+            logger.LogWarning("Could not load cert in path `{path}`, skip.", dir.FullName);
+            return;
+        }
+
+        invoked(cert);
+    }
+}

--- a/AliCdnSSLWorker/Clients/RefreshRequestClient.cs
+++ b/AliCdnSSLWorker/Clients/RefreshRequestClient.cs
@@ -4,6 +4,7 @@ using AliCdnSSLWorker.Extensions;
 using Microsoft.Extensions.Options;
 
 namespace AliCdnSSLWorker.Clients;
+
 public class RefreshRequestClient
 {
     public HttpClient Client { get; }

--- a/AliCdnSSLWorker/Configs/CertConfig.cs
+++ b/AliCdnSSLWorker/Configs/CertConfig.cs
@@ -2,14 +2,6 @@
 
 public record CertConfig
 {
-    public required string CertSearchPath { get; init; }
-
-    // ReSharper disable once StringLiteralTypo
-    public string CertFileName { get; set; } = "fullchain.pem";
-    // ReSharper disable once StringLiteralTypo
-    public string PrivateKeyFileName { get; set; } = "privkey.pem";
-
-    public bool RecursionSearch { get; init; } = true;
     public uint CacheTimeoutMin { get; init; } = 30;
 
     public HashSet<string> DomainList { get; init; } = [];

--- a/AliCdnSSLWorker/Configs/LocalProviderConfig.cs
+++ b/AliCdnSSLWorker/Configs/LocalProviderConfig.cs
@@ -1,0 +1,9 @@
+﻿namespace AliCdnSSLWorker.Configs;
+
+public record LocalCertProviderConfig
+{
+    public required string SearchPath { get; set; }
+    public required bool RecursionSearch { get; set; }
+    public required string CertFileName { get; set; } = "fullchain.pem";
+    public required string PrivateKeyFileName { get; set; } = "privkey.pem";
+}

--- a/AliCdnSSLWorker/Extensions/DependencyInjection/InterfaceServiceCollectionExtension.cs
+++ b/AliCdnSSLWorker/Extensions/DependencyInjection/InterfaceServiceCollectionExtension.cs
@@ -23,7 +23,7 @@ public static class InterfaceServiceCollectionExtension
         if (timerMonitorConfig.Get<TimerMonitorConfig>()?.Enable ?? false)
         {
             builder.Services.Configure<TimerMonitorConfig>(timerMonitorConfig);
-            builder.Services.AddHostedService<ForceMonitor>();
+            builder.Services.AddHostedService<TimerMonitor>();
         }
 
         builder.Services.AddSingleton<CertService>();

--- a/AliCdnSSLWorker/Extensions/DependencyInjection/InterfaceServiceCollectionExtension.cs
+++ b/AliCdnSSLWorker/Extensions/DependencyInjection/InterfaceServiceCollectionExtension.cs
@@ -1,0 +1,31 @@
+﻿using AliCdnSSLWorker.Configs;
+using AliCdnSSLWorker.Monitors;
+using AliCdnSSLWorker.Services;
+
+namespace AliCdnSSLWorker.Extensions.DependencyInjection;
+
+public static class InterfaceServiceCollectionExtension
+{
+    public static void AddMonitors(this HostApplicationBuilder builder)
+    {
+        builder.Services.Configure<CertConfig>(
+            builder.Configuration.GetSection(nameof(CertConfig))
+        );
+
+        var forceMonitorConfig = builder.Configuration.GetSection(nameof(ForceMonitorConfig));
+        if (forceMonitorConfig.Get<ForceMonitorConfig>()?.Enable ?? false)
+        {
+            builder.Services.Configure<ForceMonitorConfig>(forceMonitorConfig);
+            builder.Services.AddHostedService<ForceMonitor>();
+        }
+
+        var timerMonitorConfig = builder.Configuration.GetSection(nameof(TimerMonitorConfig));
+        if (timerMonitorConfig.Get<TimerMonitorConfig>()?.Enable ?? false)
+        {
+            builder.Services.Configure<TimerMonitorConfig>(timerMonitorConfig);
+            builder.Services.AddHostedService<ForceMonitor>();
+        }
+
+        builder.Services.AddSingleton<CertService>();
+    }
+}

--- a/AliCdnSSLWorker/Extensions/X509Certificate2Extension.cs
+++ b/AliCdnSSLWorker/Extensions/X509Certificate2Extension.cs
@@ -1,0 +1,44 @@
+﻿using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
+
+namespace AliCdnSSLWorker.Extensions;
+
+public static class X509Certificate2Extension
+{
+    public static bool TryExportPrivateKeyPem(this X509Certificate2 cert, out string? privateKey)
+    {
+        privateKey = null;
+
+        if (!cert.HasPrivateKey)
+            return false;
+
+        var algorithmInfo = cert.SignatureAlgorithm.Value.AsSpan();
+
+        AsymmetricAlgorithm? algorithm = null;
+
+        if (algorithmInfo.StartsWith("1.2.840.10045.4.1")
+            || algorithmInfo.StartsWith("1.2.840.10045.4.2")
+            || algorithmInfo.StartsWith("1.2.840.10045.4.3"))
+        {
+            algorithm = cert.GetECDsaPrivateKey();
+        }
+        else if (algorithmInfo.StartsWith("1.2.840.10040.4.1"))
+        {
+            algorithm = cert.GetDSAPrivateKey();
+        }
+        else if (algorithmInfo.StartsWith("1.2.840.113549.1.1"))
+        {
+            algorithm = cert.GetRSAPrivateKey();
+        }
+        else if (algorithmInfo.StartsWith("1.3.132.1.12"))
+        {
+            algorithm = cert.GetECDiffieHellmanPrivateKey();
+        }
+
+        if (algorithm is null)
+            return false;
+
+        privateKey = algorithm.ExportPkcs8PrivateKeyPem();
+        return true;
+    }
+}

--- a/AliCdnSSLWorker/Models/CertInfo.cs
+++ b/AliCdnSSLWorker/Models/CertInfo.cs
@@ -4,7 +4,7 @@ public record CertInfo
 {
     public required DateTime CertExpireDate { get; set; }
     public required DomainInfo CertCommonName { get; init; }
-    public required string FullChain { get; set; }
-    public required string PrivateKey { get; set; }
-    public required string Path { get; set; }
+    public required string? FullChain { get; set; }
+    public required string? PrivateKey { get; set; }
+    public required string IdentityName { get; set; }
 }

--- a/AliCdnSSLWorker/Models/CertInfo.cs
+++ b/AliCdnSSLWorker/Models/CertInfo.cs
@@ -1,10 +1,10 @@
 ﻿namespace AliCdnSSLWorker.Models;
 
-public record DomainCertInfo
+public record CertInfo
 {
-    public string DomainName { get; set; } = string.Empty;
     public required DateTime CertExpireDate { get; set; }
-    public required string CertCommonName { get; init; }
+    public required DomainInfo CertCommonName { get; init; }
     public required string FullChain { get; set; }
     public required string PrivateKey { get; set; }
+    public required string Path { get; set; }
 }

--- a/AliCdnSSLWorker/Program.cs
+++ b/AliCdnSSLWorker/Program.cs
@@ -1,19 +1,15 @@
 using AliCdnSSLWorker.Clients;
 using AliCdnSSLWorker.Configs;
-using AliCdnSSLWorker.Monitors;
+using AliCdnSSLWorker.Extensions.DependencyInjection;
 using AliCdnSSLWorker.Services;
 using Microsoft.ApplicationInsights.Extensibility;
 
 var builder = Host.CreateApplicationBuilder(args);
 
+builder.AddMonitors();
+
 builder.Services.Configure<AliCdnConfig>(
     builder.Configuration.GetSection(nameof(AliCdnConfig))
-);
-builder.Services.Configure<CertConfig>(
-    builder.Configuration.GetSection(nameof(CertConfig))
-);
-builder.Services.Configure<ForceMonitorConfig>(
-    builder.Configuration.GetSection(nameof(ForceMonitorConfig))
 );
 
 builder.Services.Configure<TelemetryConfiguration>(
@@ -26,10 +22,6 @@ builder.Logging.AddApplicationInsights(_ => { });
 builder.Services.AddHttpClient<RefreshRequestClient>();
 builder.Services.AddSingleton<RefreshRequestService>();
 builder.Services.AddSingleton<AliCdnService>();
-builder.Services.AddSingleton<CertService>();
-
-builder.Services.AddHostedService<TimerMonitor>();
-builder.Services.AddHostedService<ForceMonitor>();
 
 var host = builder.Build();
 var logger = host.Services.GetRequiredService<ILogger<Program>>();

--- a/AliCdnSSLWorker/Services/AliCdnService.cs
+++ b/AliCdnSSLWorker/Services/AliCdnService.cs
@@ -14,12 +14,10 @@ public class AliCdnService
 {
     private readonly ILogger<AliCdnService> _logger;
     private readonly ApiClient _apiClient;
-    private readonly RuntimeOptions _runtimeOptions = new();
+    private readonly RuntimeOptions _apiRuntimeOptions = new();
 
     public AliCdnService(ILogger<AliCdnService> logger, IOptions<AliCdnConfig> options)
     {
-        ArgumentNullException.ThrowIfNull(options);
-
         var credentialClient = new CredClient(
             new()
             {
@@ -37,24 +35,33 @@ public class AliCdnService
         _logger = logger;
     }
 
-    public bool TryGetHttpsCerts(out IEnumerable<DomainCertInfo> infos)
+    public bool TryGetRemoteCerts(out IEnumerable<CertInfo> infos)
     {
         var req = new DescribeCdnHttpsDomainListRequest();
 
         try
         {
-            var resp = _apiClient.DescribeCdnHttpsDomainListWithOptions(req, _runtimeOptions);
+            var resp = _apiClient.DescribeCdnHttpsDomainListWithOptions(req, _apiRuntimeOptions);
+            
+            // Request success
             if (resp.StatusCode == 200)
             {
-                infos = resp.Body.CertInfos.CertInfo.Select(c => new DomainCertInfo
+                infos = resp.Body.CertInfos.CertInfo.Select(c => new CertInfo
                 {
-                    DomainName = c.DomainName,
                     CertExpireDate = DateTime.Parse(c.CertExpireTime),
-                    CertCommonName = c.CertCommonName,
+                    CertCommonName = DomainInfo.Parse(c.CertCommonName),
+                    IdentityName = c.CertName,
+                    FullChain = null,
+                    PrivateKey = null
                 });
 
                 return true;
             }
+
+            // Request failed
+            _logger.LogWarning("Api return status {status}, request failed.", resp.StatusCode);
+            infos = [];
+            return false;
         }
         catch (TeaException error)
         {
@@ -65,30 +72,28 @@ public class AliCdnService
             _logger.LogError(e, "An error occured during describe cdn domain list, msg: {m}", e.Message);
         }
 
-        infos = Array.Empty<DomainCertInfo>();
+        infos = Array.Empty<CertInfo>();
         return false;
     }
 
-    public bool TryUploadCert(string domainName, (string, string) certPair)
+    public bool TryUploadCert(string domain, CertInfo certInfo)
     {
-        var (cert, privateKey) = certPair;
-
         var req = new SetCdnDomainSSLCertificateRequest
         {
-            DomainName = domainName,
-            CertName = domainName + DateTime.Now.ToShortDateString(),
+            DomainName = domain,
+            CertName = domain + DateTime.Now.ToShortDateString(),
             CertType = "upload",
             SSLProtocol = "on",
-            SSLPub = cert,
-            SSLPri = privateKey,
+            SSLPub = certInfo.FullChain,
+            SSLPri = certInfo.PrivateKey,
         };
 
-        _logger.LogInformation("Upload cert, cert `{c}` private `{p}`", cert, privateKey);
+        _logger.LogInformation("Upload cert, cert `{c}`.", certInfo.CertCommonName);
 
         try
         {
             // 复制代码运行请自行打印 API 的返回值
-            _apiClient.SetCdnDomainSSLCertificateWithOptions(req, _runtimeOptions);
+            _apiClient.SetCdnDomainSSLCertificateWithOptions(req, _apiRuntimeOptions);
             return true;
         }
         catch (TeaException error)


### PR DESCRIPTION
改了很多，将“扫描文件”的部分从服务中分离到了 Provider，将定时和 API 解构到 Monitor，将证书缓存字典等移到 CertService